### PR TITLE
Added command line for aplay (issue #7)

### DIFF
--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -1,4 +1,5 @@
 {
+   "play_wav_cmdline": "aplay -Dhw:0,0 %1",
    "enclosure": {
       "platform": "picroft",
       "update": true,


### PR DESCRIPTION
This fixes issue #7.  When you initiate the playing of a WAV file via the default, it was sometimes locking up for 30 seconds.  The problem appears to actually be between ALSA/PulseAudio on a Raspberry Pi.  From online comments, I believe this is a known issue that gets made worse on the Raspberry Pi, which generates analog audio using the CPU/interrupts.  This is not a problem when using HDMI (digital) audio.

To work around this issue, we can use a command line that explicitly bypasses PulseAudio and plays to the ALSA hardware device.  The ability to specify the "play_wav_cmdline" was added to mycroft-core, and this just adds a configuration for Picroft to uses this capability.