### PR TITLE
Split audio and custom scripts; add USB doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ After that, you can simply speak to Picroft as you would to any Mycroft implemen
 Check out the project wiki [here](https://github.com/MycroftAI/enclosure-picroft/wiki).  
 There's also the general [Documentation](https://docs.mycroft.ai/).
 
-# There are two scripts run on startu
-* audio_setup.sh configures your specific audio setup
-* custom_setup.sh is a stub meant to initialize any other IoT devices or services you might need like a DLNA server or syslog
+# There are two scripts run on startup
+* `audio_setup.sh` configures your specific audio setup.
+* `custom_setup.sh` is a stub meant to initialize any other IoT devices or services you might need like a DLNA server or syslog for example.
 
 # Using USB Audio as Output
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ After that, you can simply speak to Picroft as you would to any Mycroft implemen
 
 # Help and more info
 Check out the project wiki [here](https://github.com/MycroftAI/enclosure-picroft/wiki).  
-
 There's also the general [Documentation](https://docs.mycroft.ai/).
+
+# Using USB Audio as Output
+
+Typically the USB audio should be connected to hwplug:1,0 but to verify run the following:
+
+aplay -L
+
+Find the hwplug output for the device you want to use, take this and update the /etc/mycroft/mycroft.conf file accordingly:
+
+"play_wav_cmdline": "aplay -Dhw:0,0 %1" this line now becomes "play_wav_cmdline": "aplay -Dplughw:1,0 %1"
+
+
 

--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ Find the hwplug output for the device you want to use, take this and update the 
 
 "play_wav_cmdline": "aplay -Dhw:0,0 %1" this line now becomes "play_wav_cmdline": "aplay -Dplughw:1,0 %1"
 
+You can now run ./auto_run.sh to start the program back up and test and ensure the output comes through the USB speakers.
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ There's also the general [Documentation](https://docs.mycroft.ai/).
 
 Typically the USB audio should be connected to hwplug:1,0 but to verify run the following:
 
-aplay -L
+`aplay -L`
 
 Find the hwplug output for the device you want to use, take this and update the /etc/mycroft/mycroft.conf file accordingly:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Picroft project is an enclosure for a stock Raspberry Pi connected to a spea
 
 
  [![Download img](https://github.com/MycroftAI/enclosure-picroft/raw/master/microsd-icon.png "Download img") Picroft 0.8 image](https://rebrand.ly/Picroft-0_8)
- 
+
 
 SHA256 checksum for the PiCroft_v0.8b_Raspian_JessieLite_2017-01-26.zip image:
 ce316e13f53c261ab22a6856c397170d9dc3dd3bf4c3a5b49e10dcf668ed2c11
@@ -36,6 +36,10 @@ After that, you can simply speak to Picroft as you would to any Mycroft implemen
 Check out the project wiki [here](https://github.com/MycroftAI/enclosure-picroft/wiki).  
 There's also the general [Documentation](https://docs.mycroft.ai/).
 
+# There are two scripts run on startu
+* audio_setup.sh configures your specific audio setup
+* custom_setup.sh is a stub meant to initialize any other IoT devices or services you might need like a DLNA server or syslog
+
 # Using USB Audio as Output
 
 Typically the USB audio should be connected to hwplug:1,0 but to verify run the following:
@@ -47,5 +51,3 @@ Find the hwplug output for the device you want to use, take this and update the 
 "play_wav_cmdline": "aplay -Dhw:0,0 %1" this line now becomes "play_wav_cmdline": "aplay -Dplughw:1,0 %1"
 
 You can now run ./auto_run.sh to start the program back up and test and ensure the output comes through the USB speakers.
-
-

--- a/home/pi/audio_setup.sh
+++ b/home/pi/audio_setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+##########################################################################
+# audio_setup.sh
+##########################################################################
+# You can use this script to execute custom actions on startup.  It gets
+# called by auto_run.sh.  This file will never be replaced by an update.
+
+
+# Uncomment one of lines to change output audio such as the HDMI port, e.g. the
+# connected TV's speakers.  By default audio is output by the headphone jack.
+#
+# You can check what ALSA output you have with the command `aplay -L`
+#
+# Below are the assumed output locations for each output type.
+# While the Raspberry Pi is a standard board, these have been known to vary by
+# system; you can always use `aplay -L` to check
+# sudo amixer cset numid=3 "0"  # audio out to the USB soundcard
+# sudo amixer cset numid=3 "1"  # audio out the analog speaker/headphone jack
+# sudo amixer cset numid=3 "2"  # audio out the HDMI port (e.g. TV speakers)
+
+
+# Set the default volume level; 75 is the current default in auto_run.sh
+#
+# amixer set Master 75%
+
+
+# Any speaker output you want on startup!
+# speak "It is so good to be back online!"
+# speak "I come in peace"
+# speak "I am Mycroft. Take me to your leader!"

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -23,7 +23,7 @@ then
    # running at the local console (e.g. plugged into the HDMI output)
 
    # Make sure the audio is being output via the correct device.  You can
-   # change this to match your usage in audio_setup.sah, the default is
+   # change this to match your usage in audio_setup.sh, the default is
    # to output from the headphone jack.
    #
    sudo amixer cset numid=3 "1"   # audio out the analog speaker/headphone jack

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -31,7 +31,7 @@ then
 
    # Do not edit this script (it may be replaced later by the update process),
    # but you can edit and customize the audio_setup.sh and custom_setup.sh
-   # sscript.  Use the audio_setup.sh to change audio output configuration and
+   # script.  Use the audio_setup.sh to change audio output configuration and
    # default volume; use custom_setup.sh to initialize any other IoT devices.
    #
    # Check for custom audio setup

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -21,19 +21,26 @@ echo "***********************************************************************"
 if [ "$SSH_CLIENT" == "" ]
 then
    # running at the local console (e.g. plugged into the HDMI output)
-   
+
    # Make sure the audio is being output via the correct device.  You can
-   # change this to match your usage, the default is to output from the
-   # headphone jack.
+   # change this to match your usage in audio_setup.sah, the default is
+   # to output from the headphone jack.
    #
    sudo amixer cset numid=3 "1"   # audio out the analog speaker/headphone jack
    amixer set Master 75% # set volume to a reasonable level
 
    # Do not edit this script (it may be replaced later by the update process),
-   # but you can edit and customize the custom_setup.sh script.  You can use that
-   # to change audio config and default volume or to initialize some other IoT
-   # device.
+   # but you can edit and customize the audio_setup.sh and custom_setup.sh
+   # sscript.  Use the audio_setup.sh to change audio output configuration and
+   # default volume; use custom_setup.sh to initialize any other IoT devices.
    #
+   # Check for custom audio setup
+   if [ -f audio_setup.sh ]
+   then
+      source audio_setup.sh
+   fi
+
+   # Check for custom Device setup
    if [ -f custom_setup.sh ]
    then
       source custom_setup.sh

--- a/home/pi/custom_setup.sh
+++ b/home/pi/custom_setup.sh
@@ -5,17 +5,23 @@
 # You can use this script to execute custom actions on startup.  It gets
 # called by auto_run.sh.  This file will never be replaced by an update.
 
+# Use WakeOnLan (WOL) to wake any other machines, eg: your DLNA server
+# wakeonlan [xxMACADDRESS] # eg: 11:22:33:44:55:66
 
-# Uncomment the next line to output audio using the HDMI port, e.g. the
-# connected TV's speakers.  By default audio is output by the headphone jack.
-#
-#sudo amixer cset numid=3 "2"
-
-
-# Set the default volume level
-#
-# amixer set Master 75% 
-
+# A More complex WOL script:
+# VAR=`ping -s 1 -c 2 xxHOSTNAME > /dev/null; echo $?`
+# if [ $VAR -eq 0 ];then
+#   echo -e "xxHOSTNAME is UP as on $(date)"
+#   elif [ $VAR -eq 1 ];then
+#   wakeonlan xxMACADDRESS | echo "xxHOSTNAME not turned on. WOL packet sent at $(date +%H:%M)"
+#   sleep 3m | echo "Waiting 3 Minutes"
+#   PING=`ping -s 1 -c 4 xxHOSTNAME > /dev/null; echo $?`
+#   if [ $PING -eq 0 ];then
+#     echo "xxHOSTNAME is UP as on $(date +%H:%M)"
+#   else
+#     echo "xxHOSTNAME not turned on - Please Check Network Connections"
+#   fi
+# fi
 
 # Do anything else you want to on startup!
 #speak "It is so good to be back online!"


### PR DESCRIPTION
This splits out audio and custom script initialization.
This also future proofs a bit. Will prevent mucking in `custom_setup.sh` (which we hope people will do); from breaking the known working audio output designated in `audio_setup.sh`