### PR TITLE
Update auto_run.sh

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -345,4 +345,5 @@ echo "***********************************************************************"
 echo ""
 
 sleep 5  # for some reason this delay is needed for the mic to be detected
+cd ~/mycroft-core # This is needed for the dependency checks in start-mycroft cli to not fail
 source ~/mycroft-core/start-mycroft.sh cli


### PR DESCRIPTION
Fixed an issue that auto exited any ssh connection to pycroft after initial setup

* Description of what the PR does, such as fixes # {issue number}

Fixes issue that came up in picroft chat

* Description of how to validate or test this PR

Replace auto_run.sh in current picroft unstable image and ssh into picroft after initial install

* Whether you have signed a CLA (Contributor Licensing Agreement)

Signed