### PR TITLE
Remove WEP description from auto_run.sh first-time setup menu

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -27,7 +27,7 @@ function network_setup() {
       if [ $show_prompt = 1 ] ; then
          echo "Network connection not found, press a key to setup via keyboard"
          echo "or plug in a network cable:"
-         echo "  1) Basic wifi with SSID and password (WEP)"
+         echo "  1) Basic wifi with SSID and password"
          echo "  2) Wifi with no password"
          echo "  3) TODO: Advanced wifi"
          echo "  4) Edit wpa_supplicant.conf directly"


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}

Removes reference to WEP in first-time setup menu. Basic wifi setup also works for WPA so mentioning WEP is confusing for the user.

* Description of how to validate or test this PR

`touch ~/first_run` then `./auto_run.sh`

* Whether you have signed a CLA (Contributor Licensing Agreement)

No