### PR TITLE
Update checksum for Picroft 2018-12-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and placed into a Raspberry Pi. You can download the pre-built image here:
 
  [![Download img](https://github.com/MycroftAI/enclosure-picroft/raw/master/microsd-icon.png "Download img") Picroft 2018-9-12 unstable image](https://mycroft.ai/to/picroft-unstable)
 
-SHA-256: 98f0a28127418277f0170a692e8a95cdf6b8cb6e679d026cb515dd697f4749fb
+SHA-256: 00b6a14a2b2df7ccf09e8c3af47bb9171283be42dc8f883ee0dc5367e19d3111
 
 Optionally you can build it  yourself by following the [Recipe for building the image](image_recipe.md)
 


### PR DESCRIPTION
Update the checksum value for the latest Picroft download dated 2018-12-17

Please independently verify checksum signature.
00b6a14a2b2df7ccf09e8c3af47bb9171283be42dc8f883ee0dc5367e19d3111

* Whether you have signed a CLA (Contributor Licensing Agreement)
CLA signed.

