### PR TITLE
Fix the documentation links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Simply speak to Picroft as you would to any Mycroft.  For example:
 
 ## Help and more info
 To re-run the setup wizard, use `mycroft-setup-wizard`.
-Check out the project wiki [here](https://github.com/MycroftAI/enclosure-picroft/wiki).  
-There's also the general [Documentation](https://docs.mycroft.ai/).
+Check out the Picroft wiki [here](https://mycroft.ai/documentation/picroft/).  
+There's also the general [Documentation](https://mycroft.ai/documentation/).
 
 ## Customization
 * `audio_setup.sh` configures your specific audio setup.


### PR DESCRIPTION
update the documentation links to point to the currently correct places on:
https://mycroft.ai/documentation/

* Description of what the PR does, such as fixes # {issue number}

Yes

* Description of how to validate or test this PR

Readme.md update

* Whether you have signed a CLA (Contributor Licensing Agreement)

Yes