### PR TITLE
Tweaks to auto_run script

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -187,6 +187,8 @@ function update_software() {
     if ping -q -c 1 -W 1 1.1.1.1 >/dev/null 2>&1
     then
         echo "**** Checking for updates to Picroft environment"
+        echo "This might take a few minutes, please be patient..."
+                
         cd /tmp
         wget -N -q https://raw.githubusercontent.com/MycroftAI/enclosure-picroft/stretch/home/pi/version >/dev/null
         if [ $? -eq 0 ]

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -238,9 +238,11 @@ function setup_wizard() {
         sudo reboot
     fi
     
-    # Check for/download new software
+    # Check for/download new software (including mycroft-core dependencies, while we are at it).
     update_software
-
+    echo '{"use_branch":"master", "auto_update": true}' > ~/mycroft-core/.dev_opts.json
+    bash ~/mycroft-core/dev_setup.sh
+  
     # installs pulseaudio if not already installed
     if [ $(dpkg-query -W -f='${Status}' pulseaudio 2>/dev/null | grep -c "ok installed") -eq 0 ];
     then

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -839,7 +839,7 @@ then
     fi
 
     # Launch Mycroft Services ======================
-    source ~/mycroft-core/start-mycroft.sh all &
+    bash  "$HOME/mycroft-core/start-mycroft.sh" all &
 else
     # running in SSH session
     echo
@@ -855,6 +855,5 @@ echo "Ctrl+C to stop showing the log and return to the Linux command line."
 echo "Mycroft will continue running in the background for voice interaction."
 echo
 
-source ~/mycroft-core/start-mycroft.sh all &
 sleep 5  # for some reason this delay is needed for the mic to be detected
 "$HOME/mycroft-core/start-mycroft.sh" cli


### PR DESCRIPTION
The start-mycroft script was mistakenly being run twice on startup, including when SSHing in to the system.

Also switched from "source" to "bash".  There is not a good reason to run it in the current environment, and likely  unexpected side effects.

Finally, added a software update step right after the network connects.  This makes the experience cleaner.