### PR TITLE
Tweaks to better support Google AIY/Matrix Voice

### DIFF
--- a/home/pi/update.sh
+++ b/home/pi/update.sh
@@ -91,7 +91,7 @@ cd ~
 wget -N $REPO_PATH/home/pi/.bashrc
 wget -N $REPO_PATH/home/pi/auto_run.sh
 wget -N $REPO_PATH/home/pi/version
-wget -N $REPO_PATH/home/pi/update.sh
+wget -N $REPO_PATH/home/pi/update.sh  # updated within auto_run.sh, but download in case run directly
 
 cd ~/bin
 wget -N $REPO_PATH/home/pi/bin/mycroft-wipe


### PR DESCRIPTION
Including:
* The .setup_choices file now stores a "setup_stage", allowing the script to know where to pick up after a reboot
* Git repo status is now checked before doing a pull/dev_setup.sh combo
* Audio options are not re-displayed after a reboot for the Google AIY
* The option to start the wizard is no longer shown in the middle of a reboot that is part of the wizard
* Add PulseAudio setup to deal with long audio playback via Google AIY being cutoff
* Add amixer volume initilization for "Master", also sending output to /dev/null
* Changed "setup_matrix" flag file to ".setup_matrix"
* Tweaked the Matrix prompts and flow.  Removed several "hit any key to continue" -- required user to hang out during boring updates.