### PR TITLE
check that $stage exists

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -48,7 +48,9 @@ function save_choices() {
     if [[ "$mic" != "" && "$mic" != "null" ]] ; then
         JSON=$(echo $JSON | jq --arg mic $mic '. + {mic: $mic}')
     fi
-    JSON=$(echo $JSON | jq --arg stage $setup_stage '. + {setup_stage: $stage}')
+    if [[ "$stage" != "" && "$stage" != "null" ]] ; then
+        JSON=$(echo $JSON | jq --arg stage $setup_stage '. + {setup_stage: $stage}')
+    fi
     echo "$JSON" > ~/.setup_choices
 }
 

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -48,8 +48,8 @@ function save_choices() {
     if [[ "$mic" != "" && "$mic" != "null" ]] ; then
         JSON=$(echo $JSON | jq --arg mic $mic '. + {mic: $mic}')
     fi
-    if [[ "$stage" != "" && "$stage" != "null" ]] ; then
-        JSON=$(echo $JSON | jq --arg stage $setup_stage '. + {setup_stage: $stage}')
+    if [[ "$setup_stage" != "" && "$setup_stage" != "null" ]] ; then
+        JSON=$(echo $JSON | jq --arg stage $setup_stage '. + {setup_stage: $setup_stage}')
     fi
     echo "$JSON" > ~/.setup_choices
 }


### PR DESCRIPTION
Was receiving the `jq` helper information when running through a new install. 

Manually printing values during reruns of the script showed that `$stage` was empty, hence the setting of the variable by jq was failing.

This adds a check for `$stage` consistent with the other values being set.

