### PR TITLE
Ensure package lists are updated

### DIFF
--- a/home/pi/update.sh
+++ b/home/pi/update.sh
@@ -58,6 +58,7 @@ then
 
     # Download and setup Mycroft-core
     echo "Installing 'git'..."
+    sudo apt-get update
     sudo apt-get install git -y
 
     echo "Downloading 'mycroft-core'..."


### PR DESCRIPTION
To prevent attempts to download packages from outdated mirrors, update package lists immediately prior to installation.
