### PR TITLE
Add apt-get update before dev-setup.sh

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -251,6 +251,7 @@ function update_software() {
         git fetch
         if [ $(git rev-parse HEAD) != $(git rev-parse @{u}) ] ; then
             git pull
+            sudo apt-get -o Acquire::ForceIPv4=true update -y
             bash dev_setup.sh
         fi
         cd ~

--- a/home/pi/version
+++ b/home/pi/version
@@ -1,1 +1,1 @@
-Buster Keaton Pork Pi
+Buster Keaton - Pork Pi


### PR DESCRIPTION
Run apt-get update before dev-setup.sh is run. This is using the same option used elsewhere in the script to be consistent.

Modify version string to trigger an update.

