### PR TITLE
Ensure ~/.mycroft exists

### DIFF
--- a/home/pi/update.sh
+++ b/home/pi/update.sh
@@ -82,6 +82,7 @@ then
     echo "Retrieving default skills"
     sudo mkdir -p /opt/mycroft
     sudo chown pi:pi /opt/mycroft
+    mkdir -p ~/.mycroft
     ~/mycroft-core/bin/mycroft-msm default
 
     wget -N $REPO_PATH/home/pi/audio_setup.sh


### PR DESCRIPTION
The directory ~/.mycroft does not exist in the pi user's home dir on a clean install.

This prevents the error:
Then "INFO - building SkillEntry objects for all skills" failed with "FileNotFoundError: [Errno 2] No such file or directory: '/home/pi/.mycroft/skills.json'"

I have signed a CLA (Contributor Licensing Agreement)

