### PR TITLE
Fix for Matrix Certificate not trusted

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -815,6 +815,7 @@ then
         # add repo
         curl https://apt.matrix.one/doc/apt-key.gpg | sudo apt-key add -
         echo "deb https://apt.matrix.one/raspbian $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/matrixlabs.list
+        sudo update-ca-certificates
         sudo apt-get -o Acquire::ForceIPv4=true update -y
         sudo apt-get -o Acquire::ForceIPv4=true upgrade -y
 


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}
This is a fix for #143, by running `update-ca-certificates` it forces the system to update the certificate store.

* Description of how to validate or test this PR
Run the script & enjoy less errors.

* Whether you have signed a CLA (Contributor Licensing Agreement)
No - I couldn't find it. I agree for this to be released though.
