### PR TITLE
Fix #132 - remove hardcoded play commands

### DIFF
--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -1,6 +1,4 @@
 {
-   "play_wav_cmdline": "aplay -Dhw:0,0 %1",
-   "play_mp3_cmdline": "mpg123 -a hw:0,0 %1",
    "enclosure": {
       "platform": "picroft"
    },


### PR DESCRIPTION
Removes hardcoded play commands from Picroft. These were added as a work around for issues many moons ago. It is believed that these no longer exist in Debian Buster.

Fixes #132 


### How to test this PR
- It would be helpful if anyone running Picroft could remove these lines from their system config, reboot, and verify that output continues as expected. Please comment on this PR with your findings good or bad including the audio devices you are using.


- [x] signed a CLA (Contributor Licensing Agreement)
