### PR TITLE
Do not force sound card but fall back to ALSA config

### DIFF
--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -1,6 +1,6 @@
 {
-   "play_wav_cmdline": "aplay -Dhw:0,0 %1",
-   "play_mp3_cmdline": "mpg123 -a hw:0,0 %1",
+   "play_wav_cmdline": "aplay %1",
+   "play_mp3_cmdline": "mpg123 %1",
    "enclosure": {
       "platform": "picroft"
    },


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}

Since a recent Raspberry Pi kernel upgrade, ALSA sound card 0 device 0 is pointing to HDMI sound, if a monitor is attached, while 3.5mm jack then is card 1 device 0. Previously both were at card 0 device 0, switchable via amixer control.

Forcing now card 0 device 0 hence forces HDMI audio (even if the monitor does not really support it) and hence breaks 3.5mm jack sound. To allow switching the sound device with usual methods (ALSA configuration or raspi-config on RPi), Mycroft must not force the exact sound device. If no custom ALSA configuration exists, card 0 device 0 is the default anyway.

Related issues:
https://community.mycroft.ai/t/picroft-no-sound-with-3-5mm-jack-output/9726
https://community.mycroft.ai/t/sound-always-go-through-hdmi/9929

* Description of how to validate or test this PR
1. Boot and update a current Raspberry Pi Picroft.
2. Attach a HDMI monitor and speakers to the 3.5mm jack.
3. Use `raspi-config` to configure headphones (=3.5mm jack) for sound output.
4. Use Mycroft to play any wav or mp3 file: Prior to this commit, sound will be either heard through the HDMI monitor, if it is capable, of not at all. After this commit, sound will be heard through the speakers attached to the 3.5mm jack as selected via `raspi-config`.

* Whether you have signed a CLA (Contributor Licensing Agreement)

Yes
_________
Btw, the commented audio selection commands in this script are hence outdated as well: https://github.com/MycroftAI/enclosure-picroft/blob/buster/home/pi/audio_setup.sh
The problem is that it depends on the attached HDMI devices whether card 0 will be HDMI or 3.5mm jack, or the latter instead is card 1. Plugging of the monitor can hence as well break sound configurations. I'm hence no big fan of this new interface, but that's how it is. `raspi-config` now simply shoes the available sound cards with names to let the user select: https://github.com/RPi-Distro/raspi-config/blob/99a8ba5c74104a4c8f90c40fb4ac13df64d53fe0/raspi-config#L1925-L1952
The check above the highlighted code with `bcm2835 ALSA` sound device name btw only applies in case of outdated RPi kernel versions.