### PR TITLE
Switch from ALSA to PulseAudio

### DIFF
--- a/etc/asound.conf
+++ b/etc/asound.conf
@@ -1,0 +1,14 @@
+# Use PulseAudio by default
+pcm.!default {
+  type pulse
+  fallback "sysdefault"
+  hint {
+    show on
+    description "Default ALSA Output (currently PulseAudio Sound Server)"
+  }
+}
+
+ctl.!default {
+  type pulse
+  fallback "sysdefault"
+}

--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -1,6 +1,4 @@
 {
-   "play_wav_cmdline": "aplay -Dhw:0,0 %1",
-   "play_mp3_cmdline": "mpg123 -a hw:0,0 %1",
    "enclosure": {
       "platform": "picroft"
    },

--- a/home/pi/audio_setup.sh
+++ b/home/pi/audio_setup.sh
@@ -6,25 +6,47 @@
 # called by auto_run.sh.  This file will never be replaced by an update.
 
 
-# Uncomment one of lines to change output audio such as the HDMI port, e.g. the
-# connected TV's speakers.  By default audio is output by the headphone jack.
+# You can check what output devices are available with the command:
+# `pactl list sinks short`
 #
-# You can check what ALSA output you have with the command `aplay -L`
+# The analog headphone jack would be listed as:
+# alsa_output.platform-bcm2835_audio.analog-stereo
 #
-# Below are the assumed output locations for each output type.
-# While the Raspberry Pi is a standard board, these have been known to vary by
-# system; you can always use `aplay -L` to check
-# sudo amixer cset numid=3 "0"  # audio out to the USB soundcard
-# sudo amixer cset numid=3 "1"  # audio out the analog speaker/headphone jack
-# sudo amixer cset numid=3 "2"  # audio out the HDMI port (e.g. TV speakers)
+# The Pi's digital audio output will be listed as:
+# alsa_output.platform-bcm2835_audio.digital-stereo
+#
+# Whilst a USB speaker will be listed more explicitly eg:
+# alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo
+#
+# You can set one of these as the default PulseAudio device by uncommenting
+# one of these lines or adding your own:
+# pactl set-default-sink alsa_output.platform-bcm2835_audio.analog-stereo
+# pactl set-default-sink alsa_output.platform-bcm2835_audio.digital-stereo
+# pactl set-default-sink alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo
+# pactl set-default-sink $DEVICE_NAME
+
+
+# You can check what input devices are available with the command:
+# `pactl list sources short`
+#
+# You can set one of these as the default input device by uncommenting
+# one of these lines or adding your own:
+# pactl set-default-source alsa_output.platform-bcm2835_audio.analog-stereo
+# pactl set-default-source alsa_output.platform-bcm2835_audio.digital-stereo
+# pactl set-default-source alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo
+# pactl set-default-source $DEVICE_NAME
 
 
 # Set the default volume level; 75 is the current default in auto_run.sh
 #
-# amixer set Master 75%
+# pactl set-sink-volume @DEFAULT_SINK@ 75%
+#
+# You can set a default volume for specific output devices by using the device
+# name in place of "@DEFAULT_SINK@"
 
 
-# Any speaker output you want on startup!
+# You can make Mycroft say anything you want on startup!
+# Try uncommenting one of the following:
 # speak "It is so good to be back online!"
 # speak "I come in peace"
 # speak "I am Mycroft. Take me to your leader!"

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -321,7 +321,7 @@ function setup_wizard() {
                 read -N1 -s card_num
                 card_name=$(pactl list sinks short | awk '{print$2}' | sed -n ${card_num}p)
                 pactl set-default-sink ${card_name}
-                echo 'pactl set-default-sink ${card_name}' >> ~/audio_setup.sh
+                echo "pactl set-default-sink ${card_name}" >> ~/audio_setup.sh
                 audio="usb_audio"
                 break
                 ;;
@@ -509,7 +509,7 @@ function setup_wizard() {
                     read -N1 -s card_num
                     card_name=$(pactl list sources short | awk '{print$2}' | sed -n ${card_num}p)
                     pactl set-default-source ${card_name}
-                    echo 'pactl set-default-source ${card_name}' >> ~/audio_setup.sh
+                    echo "pactl set-default-source ${card_name}" >> ~/audio_setup.sh
                     mic="other"
                     break
                     ;;

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -691,12 +691,7 @@ function setup_wizard() {
 
 function speak() {
     # Generate TTS audio using Mimic 1
-    ~/mycroft-core/mimic/bin/mimic -t $@ -o /tmp/speak.wav
-
-    # Play the audio using the configured WAV output mechanism
-    wavcmd=$( jq -r ".play_wav_cmdline" /etc/mycroft/mycroft.conf )
-    wavcmd="${wavcmd/\%1/\/tmp\/speak.wav}"
-    $( $wavcmd >/dev/null 2>&1 )
+    ~/mycroft-core/mimic/bin/mimic -t $@
 }
 
 ######################

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -313,7 +313,7 @@ function setup_wizard() {
              3)
                 echo "$key - USB audio"
                 # audio out to the USB soundcard
-                echo "Select your soundcard"
+                echo "Select your output device"
                 pactl list sinks short | awk '{printf("  %d) %s\n", NR, $2)}'
                 echo -n "${HIGHLIGHT}Choice:${RESET} "
                 read -N1 -s card_num
@@ -493,10 +493,17 @@ function setup_wizard() {
                     ;;
                 4)
                     echo "$key - Other"
-                    echo "Other microphone _might_ work, but there are no guarantees."
+                    echo "Other microphones _might_ work, but there are no guarantees."
                     echo "We'll run the tests, but you are on your own.  If you have"
                     echo "issues, the most likely cause is an incompatible microphone."
                     echo "The PS Eye is cheap -- save yourself hassle and just buy one!"
+                    echo ""
+                    echo "Select your input device"
+                    pactl list sources short | awk '{printf("  %d) %s\n", NR, $2)}'
+                    echo -n "${HIGHLIGHT}Choice:${RESET} "
+                    read -N1 -s card_num
+                    card_name=$(pactl list sources short | awk '{print$2}' | sed -n ${card_num}p)
+                    pactl set-default-source ${card_name}
                     mic="other"
                     break
                     ;;

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -300,6 +300,7 @@ function setup_wizard() {
                 echo "$key - Analog audio"
                 # audio out the analog speaker/headphone jack
                 pactl set-default-sink alsa_output.platform-bcm2835_audio.analog-stereo
+                echo 'pactl set-default-sink alsa_output.platform-bcm2835_audio.analog-stereo' >> ~/audio_setup.sh
                 audio="analog_audio"
                 break
                 ;;
@@ -307,6 +308,7 @@ function setup_wizard() {
                 echo "$key - HDMI audio"
                 # audio out the HDMI port (e.g. TV speakers)
                 pactl set-default-sink alsa_output.platform-bcm2835_audio.digital-stereo
+                echo 'pactl set-default-sink alsa_output.platform-bcm2835_audio.digital-stereo' >> ~/audio_setup.sh
                 audio="hdmi_audio"
                 break
                 ;;
@@ -319,6 +321,7 @@ function setup_wizard() {
                 read -N1 -s card_num
                 card_name=$(pactl list sinks short | awk '{print$2}' | sed -n ${card_num}p)
                 pactl set-default-sink ${card_name}
+                echo 'pactl set-default-sink ${card_name}' >> ~/audio_setup.sh
                 audio="usb_audio"
                 break
                 ;;
@@ -383,6 +386,8 @@ function setup_wizard() {
                 # Configure PulseAudio to use Seeed device
                 pactl set-default-source alsa_input.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-mono
                 pactl set-default-sink alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo
+                echo 'pactl set-default-source alsa_input.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-mono' >> ~/audio_setup.sh
+                echo 'pactl set-default-sink alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo' >> ~/audio_setup.sh
 
                 audio="seed_mic_array_20"
                 break
@@ -504,6 +509,7 @@ function setup_wizard() {
                     read -N1 -s card_num
                     card_name=$(pactl list sources short | awk '{print$2}' | sed -n ${card_num}p)
                     pactl set-default-source ${card_name}
+                    echo 'pactl set-default-source ${card_name}' >> ~/audio_setup.sh
                     mic="other"
                     break
                     ;;

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -74,18 +74,15 @@ function save_choices() {
 }
 
 function set_volume() {
-    # Use amixer to set the volume level
-    # This attempts to set both "Master" and "PCM"
+    # Use PulseAudio to set the volume level
 
-    amixer set PCM $@ > /dev/null 2>&1
-    amixer set Master $@ > /dev/null 2>&1
+    pactl set-sink-volume @DEFAULT_SINK@ $@
 }
 
 function save_volume() {
-    # Save command to amixer to set the volume level
+    # Save PulseAudio volume command to set the default volume level
 
-    echo "amixer set PCM $@ > /dev/null 2>&1" >> ~/audio_setup.sh
-    echo "amixer set Master $@ > /dev/null 2>&1" >> ~/audio_setup.sh
+    echo "pactl set-sink-volume @DEFAULT_SINK@ $@" >> ~/audio_setup.sh
 }
 
 function network_setup() {
@@ -302,24 +299,26 @@ function setup_wizard() {
              1)
                 echo "$key - Analog audio"
                 # audio out the analog speaker/headphone jack
-                sudo amixer cset numid=3 "1" > /dev/null 2>&1
-                echo 'sudo amixer cset numid=3 "1" > /dev/null 2>&1' >> ~/audio_setup.sh
+                pactl set-default-sink alsa_output.platform-bcm2835_audio.analog-stereo
                 audio="analog_audio"
                 break
                 ;;
              2)
                 echo "$key - HDMI audio"
                 # audio out the HDMI port (e.g. TV speakers)
-                sudo amixer cset numid=3 "2" > /dev/null 2>&1
-                echo 'sudo amixer cset numid=3 "2"  > /dev/null 2>&1' >> ~/audio_setup.sh
+                pactl set-default-sink alsa_output.platform-bcm2835_audio.digital-stereo
                 audio="hdmi_audio"
                 break
                 ;;
              3)
                 echo "$key - USB audio"
                 # audio out to the USB soundcard
-                sudo amixer cset numid=3 "0" > /dev/null 2>&1
-                echo 'sudo amixer cset numid=3 "0"  > /dev/null 2>&1' >> ~/audio_setup.sh
+                echo "Select your soundcard"
+                pactl list sinks short | awk '{printf("  %d) %s\n", NR, $2)}'
+                echo -n "${HIGHLIGHT}Choice:${RESET} "
+                read -N1 -s card_num
+                card_name=$(pactl list sinks short | awk '{print$2}' | sed -n ${card_num}p)
+                pactl set-default-sink ${card_name}
                 audio="usb_audio"
                 break
                 ;;
@@ -355,12 +354,6 @@ function setup_wizard() {
                 # See: https://github.com/google/aiyprojects-raspbian/issues/297
                 sudo sed -i -e "s/^load-module module-suspend-on-idle/#load-module module-suspend-on-idle/" /etc/pulse/default.pa
 
-                # Changes mycroft.conf to use the default output device
-                sudo sed -i \
-                    -e "s/aplay -Dhw:0,0 %1/aplay %1/" \
-                    -e "s/mpg123 -a hw:0,0 %1/mpg123 %1/" \
-                    /etc/mycroft/mycroft.conf
-
                 # Install asound.conf
                 sudo cp AIY-asound.conf /etc/asound.conf
 
@@ -387,11 +380,9 @@ function setup_wizard() {
                 sudo /home/pi/mycroft-core/.venv/bin/python dfu.py --download 1_channel_firmware.bin
                 cd ..
 
-                # Configure Mycroft to use plughw:ArrayUAC10,0 (Seeed device)
-                sudo sed -i \
-                    -e "s/aplay -Dhw:0,0 %1/aplay -Dplughw:ArrayUAC10,0 %1/" \
-                    -e "s/mpg123 -a hw:0,0 %1/mpg123 -a plughw:ArrayUAC10,0 %1/" \
-                    /etc/mycroft/mycroft.conf
+                # Configure PulseAudio to use Seeed device
+                pactl set-default-source alsa_input.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-mono
+                pactl set-default-sink alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo
 
                 audio="seed_mic_array_20"
                 break
@@ -876,7 +867,7 @@ then
     # the script will likely be overwritten during later updates.
     #
     # Default to analog audio jack at 75% volume
-    amixer cset numid=3 "1" > /dev/null 2>&1
+    pactl set-default-sink alsa_output.platform-bcm2835_audio.analog-stereo
     set_volume 75%
 
     # Check for custom audio setup


### PR DESCRIPTION
Switches all ALSA commands to use PulseAudio
- Sets input and output devices as default devices in PA
- Provides a new selection menu for non-standard devices using the output of `pactl info list sinks/sources short`
- Set volume using PA
- As the devices are now set as defaults, we no longer need to set custom `play_type_cmdline` settings for each device, hence these mycroft.conf settings have been removed.
- Simplifies the speak function as Mimic can now output audio directly, reducing chance of tmp file issues

This fixes the issues raised in PR #150 that are present in the newer RPi kernel.

#### Description of how to validate or test this PR
1. Fire up a fresh copy of Picroft or run `mycroft-wipe`
2. Apply new files
3. Set up as normal - should just be a nice experience...

If you need to run the wizard again as if it was fresh:
```
touch first_run
rm .setup_choices
. auto_run.sh
```

#### CLA
- [x] Yes
