### PR TITLE
Add mycroft-setup-wizard command

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -744,8 +744,6 @@ echo "**                       $mycroft_core_ver ( ${mycroft_core_branch/* /} )"
 echo "***********************************************************************"
 sleep 2  # give user a few moments to notice the version
 
-alias mycroft-setup-wizard="cd ~ && touch first_run && rm -f .setup_choices && rm -f .setup_stage && source auto_run.sh"
-
 if [ -f ~/first_run ]
 then
     $(bash "$HOME/mycroft-core/stop-mycroft.sh" all > /dev/null)

--- a/home/pi/bin/mycroft-setup-wizard
+++ b/home/pi/bin/mycroft-setup-wizard
@@ -1,0 +1,5 @@
+cd $HOME 
+touch first_run
+rm -f .setup_choices
+rm -f .setup_stage
+source auto_run.sh


### PR DESCRIPTION
For some reason the `mycroft-setup-wizard` alias no longer exists. This re-adds the command.

It was previously set as an alias in `.bashrc` but as described in #124 this only worked for local sessions, not over SSH. To fix #124 this adds the equivalent command to the `~/bin/` directory.

Currently this does not scrub the previously input choices eg any lines added to `audio_setup.sh` by previous runs of the wizard. Any new lines should however be executed after the old ones so will take precedence. By not scrubbing it the user can exit the wizard and retain their previous settings. This seems safer and is consistent with the existing behaviour of the alias.

#### Description of how to validate or test this PR
Add this and call it over an SSH session.

#### CLA
- [x] Yes
