### PR TITLE
fix pulseaudio cardname audio_setup.sh generation

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -321,7 +321,7 @@ function setup_wizard() {
                 read -N1 -s card_num
                 card_name=$(pactl list sinks short | awk '{print$2}' | sed -n ${card_num}p)
                 pactl set-default-sink ${card_name}
-                echo 'pactl set-default-sink ${card_name}' >> ~/audio_setup.sh
+                echo "pactl set-default-sink ${card_name}" >> ~/audio_setup.sh
                 audio="usb_audio"
                 break
                 ;;
@@ -509,7 +509,7 @@ function setup_wizard() {
                     read -N1 -s card_num
                     card_name=$(pactl list sources short | awk '{print$2}' | sed -n ${card_num}p)
                     pactl set-default-source ${card_name}
-                    echo 'pactl set-default-source ${card_name}' >> ~/audio_setup.sh
+                    echo "pactl set-default-source ${card_name}" >> ~/audio_setup.sh
                     mic="other"
                     break
                     ;;


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}

PR against the feature/pulseaudio branch; single ticks prevent cardname interpolation.  See https://community.mycroft.ai/t/picroft-headphones-no-output-sound/10852/15

* Description of how to validate or test this PR

Choose a custom USB sink and source. View the audio_setup.sh before this PR (contains ${card_name} literally), after contains the interpolated card name.

* Whether you have signed a CLA (Contributor Licensing Agreement)

No.