### PR TITLE
Remove aiy-voicebonnet-routes from auto_run.sh

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -337,7 +337,7 @@ function setup_wizard() {
                 sudo mkdir /usr/lib/systemd/system
 
                 sudo apt-get -y install aiy-dkms aiy-io-mcu-firmware aiy-vision-firmware dkms raspberrypi-kernel-headers
-                sudo apt-get -y install aiy-dkms aiy-voicebonnet-soundcard-dkms aiy-voicebonnet-routes
+                sudo apt-get -y install aiy-dkms aiy-voicebonnet-soundcard-dkms
                 # At this time, 12/17/2018, installing aiy-python-wheels breaks the install
                 # https://community.mycroft.ai/t/setting-up-aiy-python-wheels-protobuf-not-supported-on-armv6-1/5130/2
                 # sudo apt-get install -y aiy-python-wheels


### PR DESCRIPTION
This is no longer in the Google repo and causes setup to crash.

```shell
$ grep -h -P -o "^Package: \K.*" /var/lib/apt/lists/packages.cloud.google.com_apt_dists_aiyprojects-stable_main_binary-armhf_Packages 
aiy-board-info
aiy-bt-prov-server
aiy-cwc-server
aiy-dkms
aiy-dummy
aiy-io-mcu-firmware
aiy-models
aiy-overlay-vision
aiy-overlay-voice
aiy-python-wheels
aiy-usb-gadget
aiy-vision-dkms
aiy-vision-firmware
aiy-voice-services
aiy-voicebonnet-soundcard-dkms
leds-ktd202x-dkms
pwm-soft-dkms
```
